### PR TITLE
(#14) Read ./.hiera as data

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ At a broad level this is what we hope to achieve
 
  * `apt` provider for the `package` type, improve the `dnf` provider
  * `file` type
- * `service` type that supports `systemd
  * `exec` type
- * Relationships allowing service to refresh if a file changes
- * Support relationships in a shell script
  * Choria Autonomous Agent integration
+ * Explore `hcl` as a manifest format
+ * ~~`service` type that supports `systemd~~
+ * ~~Relationships allowing service to refresh if a file changes~~
+ * ~~Support relationships in a shell script~~
+ * ~~Support hiera data in shell script via `.hiera`~~
 
 ## Facts
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -27,7 +27,6 @@ func registerApplyCommand(ccm *fisk.Application) {
 	apply.Arg("manifest", "Path to manifest to apply").ExistingFileVar(&cmd.manifest)
 	apply.Flag("render", "Do not apply, only render the resolved manifest").UnNegatableBoolVar(&cmd.renderOnly)
 	apply.Flag("report", "Generate a report").Default("true").BoolVar(&cmd.report)
-
 }
 
 func (c *applyCommand) applyAction(_ *fisk.ParseContext) error {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -21,6 +21,11 @@ func ExecutableInPath(file string) (string, bool, error) {
 	return f, err == nil, err
 }
 
+func FileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 func IsDirectory(path string) bool {
 	stat, err := os.Stat(path)
 	if errors.Is(err, os.ErrNotExist) {

--- a/resources/package/type.go
+++ b/resources/package/type.go
@@ -41,11 +41,6 @@ var _ model.Resource = (*Type)(nil)
 
 // New creates a new package resource with the given properties
 func New(ctx context.Context, mgr model.Manager, properties model.PackageResourceProperties) (*Type, error) {
-	logger, err := mgr.Logger("type", model.PackageTypeName, "name", properties.Name)
-	if err != nil {
-		return nil, err
-	}
-
 	data := mgr.Data()
 	facts, err := mgr.Facts(ctx)
 	if err != nil {
@@ -58,6 +53,11 @@ func New(ctx context.Context, mgr model.Manager, properties model.PackageResourc
 	}
 
 	err = properties.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	logger, err := mgr.Logger("type", model.PackageTypeName, "name", properties.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/resources/service/type.go
+++ b/resources/service/type.go
@@ -34,11 +34,6 @@ var _ model.Resource = (*Type)(nil)
 
 // New creates a new service resource with the given properties
 func New(ctx context.Context, mgr model.Manager, properties model.ServiceResourceProperties) (*Type, error) {
-	logger, err := mgr.Logger("type", model.ServiceTypeName, "name", properties.Name)
-	if err != nil {
-		return nil, err
-	}
-
 	data := mgr.Data()
 	facts, err := mgr.Facts(ctx)
 	if err != nil {
@@ -51,6 +46,11 @@ func New(ctx context.Context, mgr model.Manager, properties model.ServiceResourc
 	}
 
 	err = properties.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	logger, err := mgr.Logger("type", model.ServiceTypeName, "name", properties.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/session/memory.go
+++ b/session/memory.go
@@ -50,11 +50,6 @@ func (s *MemorySessionStore) RecordEvent(event model.SessionEvent) error {
 
 	s.events = append(s.events, event)
 
-	te, ok := event.(*model.TransactionEvent)
-	if ok {
-		te.LogStatus(s.out)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
When ./.hiera exists, read it, evaluate it and use as data for ccm ensure.