### PR TITLE
(#93) Add http support for manifest bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ coverage.out
 coverage.html
 *.test
 AGENTS.md
+CLAUDE.md
 manifest.yaml
 *.patch
+.DS_Store

--- a/agent/http.go
+++ b/agent/http.go
@@ -1,0 +1,255 @@
+// Copyright (c) 2026, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/choria-io/ccm/internal/backoff"
+	iu "github.com/choria-io/ccm/internal/util"
+	"github.com/choria-io/ccm/metrics"
+)
+
+// maintainHttpCache periodically checks an HTTP(S) URL for changes and updates the local cache.
+// It uses HEAD requests with Last-Modified/ETag headers for change detection.
+func (w *worker) maintainHttpCache(wg *sync.WaitGroup, manifestUrl *url.URL) {
+	ticker := time.NewTicker(objectMaintInterval)
+	w.fetchNotify = make(chan struct{}, 1)
+	w.fetchNotify <- struct{}{} // Trigger initial fetch
+
+	redactedUrl := iu.RedactUrlCredentials(manifestUrl)
+	tries := 0
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for {
+			select {
+			case <-w.fetchNotify:
+				changed, err := w.checkHttpChanged(manifestUrl)
+				if err != nil {
+					metrics.AgentManifestFetchFailureCount.WithLabelValues(w.source).Inc()
+					tries++
+					w.log.Error("Could not check HTTP manifest for changes", "url", redactedUrl, "error", err)
+					backoff.Default.AfterFunc(tries, func() {
+						select {
+						case w.fetchNotify <- struct{}{}:
+						default:
+						}
+					})
+					continue
+				}
+
+				if !changed {
+					w.log.Debug("HTTP manifest unchanged", "url", redactedUrl)
+					tries = 0
+					continue
+				}
+
+				err = w.getHttpFile(manifestUrl)
+				if err != nil {
+					metrics.AgentManifestFetchFailureCount.WithLabelValues(w.source).Inc()
+					tries++
+					w.log.Error("Could not fetch HTTP manifest", "url", redactedUrl, "error", err)
+					backoff.Default.AfterFunc(tries, func() {
+						select {
+						case w.fetchNotify <- struct{}{}:
+						default:
+						}
+					})
+					continue
+				}
+				tries = 0
+
+			case <-ticker.C:
+				ticker.Reset(objectMaintInterval)
+				select {
+				case w.fetchNotify <- struct{}{}:
+				default:
+				}
+
+			case <-w.ctx.Done():
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+// checkHttpChanged performs a HEAD request to check if the HTTP resource has changed.
+// Returns true if the resource needs to be fetched, false if unchanged.
+func (w *worker) checkHttpChanged(manifestUrl *url.URL) (bool, error) {
+	// If server doesn't support caching headers, we've already fetched once
+	if w.httpNoCacheHeaders {
+		return false, nil
+	}
+
+	// First fetch - no cached headers yet
+	if w.httpLastModified == "" && w.httpETag == "" {
+		return true, nil
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(w.ctx, 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(timeoutCtx, http.MethodHead, manifestUrl.String(), nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create HEAD request: %w", err)
+	}
+
+	// Add Basic Auth if credentials are provided in the URL
+	if manifestUrl.User != nil {
+		username := manifestUrl.User.Username()
+		password, _ := manifestUrl.User.Password()
+		req.SetBasicAuth(username, password)
+	}
+
+	// Add conditional headers
+	if w.httpLastModified != "" {
+		req.Header.Set("If-Modified-Since", w.httpLastModified)
+	}
+	if w.httpETag != "" {
+		req.Header.Set("If-None-Match", w.httpETag)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("HEAD request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNotModified:
+		// 304 - content hasn't changed
+		return false, nil
+
+	case http.StatusOK:
+		// Check if headers indicate a change
+		newLastModified := resp.Header.Get("Last-Modified")
+		newETag := resp.Header.Get("ETag")
+
+		// Check for changes based on headers
+		if newETag != "" && newETag != w.httpETag {
+			return true, nil
+		}
+		if newLastModified != "" && newLastModified != w.httpLastModified {
+			return true, nil
+		}
+
+		// Headers match, no change
+		return false, nil
+
+	default:
+		return false, fmt.Errorf("unexpected HTTP status: %d %s", resp.StatusCode, resp.Status)
+	}
+}
+
+// getHttpFile downloads the manifest from an HTTP URL and caches it locally.
+func (w *worker) getHttpFile(manifestUrl *url.URL) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	metrics.AgentManifestFetchCount.WithLabelValues(w.source).Inc()
+
+	redactedUrl := iu.RedactUrlCredentials(manifestUrl)
+	w.log.Warn("Fetching manifest from HTTP", "url", redactedUrl)
+
+	timeoutCtx, cancel := context.WithTimeout(w.ctx, time.Minute)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(timeoutCtx, http.MethodGet, manifestUrl.String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create GET request: %w", err)
+	}
+
+	// Add Basic Auth if credentials are provided in the URL
+	if manifestUrl.User != nil {
+		username := manifestUrl.User.Username()
+		password, _ := manifestUrl.User.Password()
+		req.SetBasicAuth(username, password)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP request failed with status %d: %s", resp.StatusCode, resp.Status)
+	}
+
+	// Store cache validation headers for next check
+	w.httpLastModified = resp.Header.Get("Last-Modified")
+	w.httpETag = resp.Header.Get("ETag")
+
+	// Check if server supports caching headers
+	if w.httpLastModified == "" && w.httpETag == "" {
+		w.httpNoCacheHeaders = true
+		w.log.Warn("HTTP server does not support Last-Modified or ETag headers, change detection disabled", "url", redactedUrl)
+	}
+
+	// Create temp directory for extraction
+	cleanedPath := w.cleanHttpPath(manifestUrl)
+	tf, err := os.MkdirTemp(w.cacheDir, fmt.Sprintf("http-%s.*", cleanedPath))
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tf)
+
+	// Extract tar.gz directly from response body (streaming)
+	files, err := iu.UntarGz(resp.Body, tf)
+	if err != nil {
+		return err
+	}
+
+	// Find manifest.yaml
+	manifestPath, err := iu.FindManifestInFiles(files, tf)
+	if err != nil {
+		return fmt.Errorf("%w in fetched file", err)
+	}
+
+	// Atomic rename to final location
+	target := filepath.Join(w.cacheDir, fmt.Sprintf("http_%s", cleanedPath))
+	if iu.FileExists(target) {
+		err = os.RemoveAll(target)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = os.Rename(tf, target)
+	if err != nil {
+		return err
+	}
+
+	w.manifestPath = filepath.Join(target, manifestPath)
+
+	w.log.Debug("HTTP manifest cached", "target", target, "manifest", w.manifestPath)
+	w.mgr.SetWorkingDirectory(filepath.Dir(w.manifestPath))
+
+	w.triggerApply()
+
+	return nil
+}
+
+// cleanHttpPath creates a filesystem-safe identifier from a URL.
+func (w *worker) cleanHttpPath(u *url.URL) string {
+	path := u.Host + u.Path
+	path = strings.ReplaceAll(path, "/", "_")
+	path = strings.ReplaceAll(path, ":", "_")
+	path = strings.TrimSuffix(path, ".tar.gz")
+	path = strings.TrimSuffix(path, ".tgz")
+	return path
+}

--- a/agent/http_test.go
+++ b/agent/http_test.go
@@ -1,0 +1,489 @@
+// Copyright (c) 2026, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	"github.com/choria-io/ccm/model/modelmocks"
+)
+
+// Tests are run via TestConfig in config_test.go
+
+// createTarGz creates a tar.gz archive containing a manifest.yaml file
+func createTarGz(manifestContent string) (*bytes.Buffer, error) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	// Add manifest.yaml
+	hdr := &tar.Header{
+		Name: "manifest.yaml",
+		Mode: 0644,
+		Size: int64(len(manifestContent)),
+	}
+	if err := tw.WriteHeader(hdr); err != nil {
+		return nil, err
+	}
+	if _, err := tw.Write([]byte(manifestContent)); err != nil {
+		return nil, err
+	}
+
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	if err := gw.Close(); err != nil {
+		return nil, err
+	}
+
+	return &buf, nil
+}
+
+var _ = Describe("cleanHttpPath", func() {
+	It("creates a filesystem-safe path from URL", func() {
+		w := &worker{}
+
+		u, _ := url.Parse("https://example.com:8443/path/to/manifest.tar.gz")
+		result := w.cleanHttpPath(u)
+		Expect(result).To(Equal("example.com_8443_path_to_manifest"))
+	})
+
+	It("handles URLs without port", func() {
+		w := &worker{}
+
+		u, _ := url.Parse("https://example.com/manifest.tgz")
+		result := w.cleanHttpPath(u)
+		Expect(result).To(Equal("example.com_manifest"))
+	})
+
+	It("handles URLs with multiple path segments", func() {
+		w := &worker{}
+
+		u, _ := url.Parse("https://cdn.example.com/releases/v1.0/app.tar.gz")
+		result := w.cleanHttpPath(u)
+		Expect(result).To(Equal("cdn.example.com_releases_v1.0_app"))
+	})
+})
+
+var _ = Describe("checkHttpChanged", func() {
+	var (
+		mockctl *gomock.Controller
+		mockLog *modelmocks.MockLogger
+		mockMgr *modelmocks.MockManager
+		w       *worker
+		server  *httptest.Server
+		ctx     context.Context
+		cancel  context.CancelFunc
+	)
+
+	BeforeEach(func() {
+		mockctl = gomock.NewController(GinkgoT())
+		mockLog = modelmocks.NewMockLogger(mockctl)
+		mockMgr = modelmocks.NewMockManager(mockctl)
+		ctx, cancel = context.WithCancel(context.Background())
+
+		mockLog.EXPECT().Debug(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Info(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Warn(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Error(gomock.Any(), gomock.Any()).AnyTimes()
+
+		w = &worker{
+			ctx: ctx,
+			log: mockLog,
+			mgr: mockMgr,
+		}
+	})
+
+	AfterEach(func() {
+		cancel()
+		mockctl.Finish()
+		if server != nil {
+			server.Close()
+		}
+	})
+
+	It("returns true on first check (no cached headers)", func() {
+		u, _ := url.Parse("https://example.com/manifest.tar.gz")
+		changed, err := w.checkHttpChanged(u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeTrue())
+	})
+
+	It("returns false when httpNoCacheHeaders is true", func() {
+		w.httpNoCacheHeaders = true
+		u, _ := url.Parse("https://example.com/manifest.tar.gz")
+		changed, err := w.checkHttpChanged(u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeFalse())
+	})
+
+	It("returns false when server returns 304 Not Modified", func() {
+		server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodHead {
+				if r.Header.Get("If-None-Match") == `"etag123"` {
+					rw.WriteHeader(http.StatusNotModified)
+					return
+				}
+			}
+			rw.WriteHeader(http.StatusOK)
+		}))
+
+		u, _ := url.Parse(server.URL + "/manifest.tar.gz")
+		w.httpETag = `"etag123"`
+
+		changed, err := w.checkHttpChanged(u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeFalse())
+	})
+
+	It("returns true when ETag changes", func() {
+		server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.Header().Set("ETag", `"new-etag"`)
+			rw.WriteHeader(http.StatusOK)
+		}))
+
+		u, _ := url.Parse(server.URL + "/manifest.tar.gz")
+		w.httpETag = `"old-etag"`
+
+		changed, err := w.checkHttpChanged(u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeTrue())
+	})
+
+	It("returns true when Last-Modified changes", func() {
+		server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.Header().Set("Last-Modified", "Wed, 15 Jan 2026 12:00:00 GMT")
+			rw.WriteHeader(http.StatusOK)
+		}))
+
+		u, _ := url.Parse(server.URL + "/manifest.tar.gz")
+		w.httpLastModified = "Wed, 01 Jan 2026 12:00:00 GMT"
+
+		changed, err := w.checkHttpChanged(u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeTrue())
+	})
+
+	It("returns false when headers match", func() {
+		server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.Header().Set("ETag", `"same-etag"`)
+			rw.Header().Set("Last-Modified", "Wed, 01 Jan 2026 12:00:00 GMT")
+			rw.WriteHeader(http.StatusOK)
+		}))
+
+		u, _ := url.Parse(server.URL + "/manifest.tar.gz")
+		w.httpETag = `"same-etag"`
+		w.httpLastModified = "Wed, 01 Jan 2026 12:00:00 GMT"
+
+		changed, err := w.checkHttpChanged(u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changed).To(BeFalse())
+	})
+
+	It("returns error for HTTP errors", func() {
+		server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.WriteHeader(http.StatusInternalServerError)
+		}))
+
+		u, _ := url.Parse(server.URL + "/manifest.tar.gz")
+		w.httpETag = `"some-etag"`
+
+		_, err := w.checkHttpChanged(u)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("500"))
+	})
+
+	It("sends Basic Auth when URL has credentials", func() {
+		var receivedAuth string
+		server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			receivedAuth = r.Header.Get("Authorization")
+			rw.Header().Set("ETag", `"new-etag"`)
+			rw.WriteHeader(http.StatusOK)
+		}))
+
+		u, _ := url.Parse(server.URL + "/manifest.tar.gz")
+		u.User = url.UserPassword("testuser", "testpass")
+		w.httpETag = `"old-etag"`
+
+		_, err := w.checkHttpChanged(u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(receivedAuth).To(HavePrefix("Basic "))
+	})
+})
+
+var _ = Describe("getHttpFile", func() {
+	var (
+		mockctl  *gomock.Controller
+		mockLog  *modelmocks.MockLogger
+		mockMgr  *modelmocks.MockManager
+		w        *worker
+		server   *httptest.Server
+		ctx      context.Context
+		cancel   context.CancelFunc
+		cacheDir string
+	)
+
+	BeforeEach(func() {
+		mockctl = gomock.NewController(GinkgoT())
+		mockLog = modelmocks.NewMockLogger(mockctl)
+		mockMgr = modelmocks.NewMockManager(mockctl)
+		ctx, cancel = context.WithCancel(context.Background())
+
+		mockLog.EXPECT().Debug(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Info(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Warn(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Error(gomock.Any(), gomock.Any()).AnyTimes()
+
+		var err error
+		cacheDir, err = os.MkdirTemp("", "http-cache-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		w = &worker{
+			ctx:         ctx,
+			log:         mockLog,
+			mgr:         mockMgr,
+			cacheDir:    cacheDir,
+			applyNotify: make(chan struct{}, 1),
+		}
+	})
+
+	AfterEach(func() {
+		cancel()
+		mockctl.Finish()
+		if server != nil {
+			server.Close()
+		}
+		os.RemoveAll(cacheDir)
+	})
+
+	It("downloads and extracts manifest successfully", func() {
+		manifestContent := `
+name: test
+resources: []
+`
+		tarGz, err := createTarGz(manifestContent)
+		Expect(err).NotTo(HaveOccurred())
+
+		server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.Header().Set("ETag", `"test-etag"`)
+			rw.Header().Set("Last-Modified", "Wed, 15 Jan 2026 12:00:00 GMT")
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write(tarGz.Bytes())
+		}))
+
+		mockMgr.EXPECT().SetWorkingDirectory(gomock.Any()).Times(1)
+
+		u, _ := url.Parse(server.URL + "/manifest.tar.gz")
+		err = w.getHttpFile(u)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify cached headers
+		Expect(w.httpETag).To(Equal(`"test-etag"`))
+		Expect(w.httpLastModified).To(Equal("Wed, 15 Jan 2026 12:00:00 GMT"))
+
+		// Verify manifest path is set
+		Expect(w.manifestPath).NotTo(BeEmpty())
+		Expect(filepath.Base(w.manifestPath)).To(Equal("manifest.yaml"))
+
+		// Verify file exists
+		_, err = os.Stat(w.manifestPath)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("sets httpNoCacheHeaders when server has no cache headers", func() {
+		manifestContent := `
+name: test
+resources: []
+`
+		tarGz, err := createTarGz(manifestContent)
+		Expect(err).NotTo(HaveOccurred())
+
+		server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write(tarGz.Bytes())
+		}))
+
+		mockMgr.EXPECT().SetWorkingDirectory(gomock.Any()).Times(1)
+
+		u, _ := url.Parse(server.URL + "/manifest.tar.gz")
+		err = w.getHttpFile(u)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(w.httpNoCacheHeaders).To(BeTrue())
+	})
+
+	It("returns error when manifest.yaml is missing", func() {
+		// Create tar.gz without manifest.yaml
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gw)
+
+		hdr := &tar.Header{
+			Name: "other.yaml",
+			Mode: 0644,
+			Size: 4,
+		}
+		_ = tw.WriteHeader(hdr)
+		_, _ = tw.Write([]byte("test"))
+		_ = tw.Close()
+		_ = gw.Close()
+
+		server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write(buf.Bytes())
+		}))
+
+		u, _ := url.Parse(server.URL + "/manifest.tar.gz")
+		err := w.getHttpFile(u)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("manifest.yaml not found"))
+	})
+
+	It("returns error for non-200 status codes", func() {
+		server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.WriteHeader(http.StatusNotFound)
+		}))
+
+		u, _ := url.Parse(server.URL + "/manifest.tar.gz")
+		err := w.getHttpFile(u)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("404"))
+	})
+
+	It("sends Basic Auth when URL has credentials", func() {
+		manifestContent := `
+name: test
+resources: []
+`
+		tarGz, err := createTarGz(manifestContent)
+		Expect(err).NotTo(HaveOccurred())
+
+		var receivedAuth string
+		server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			receivedAuth = r.Header.Get("Authorization")
+			rw.Header().Set("ETag", `"test-etag"`)
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write(tarGz.Bytes())
+		}))
+
+		mockMgr.EXPECT().SetWorkingDirectory(gomock.Any()).Times(1)
+
+		u, _ := url.Parse(server.URL + "/manifest.tar.gz")
+		u.User = url.UserPassword("testuser", "testpass")
+
+		err = w.getHttpFile(u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(receivedAuth).To(HavePrefix("Basic "))
+	})
+
+	It("triggers apply after successful download", func() {
+		manifestContent := `
+name: test
+resources: []
+`
+		tarGz, err := createTarGz(manifestContent)
+		Expect(err).NotTo(HaveOccurred())
+
+		server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			rw.Header().Set("ETag", `"test-etag"`)
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write(tarGz.Bytes())
+		}))
+
+		mockMgr.EXPECT().SetWorkingDirectory(gomock.Any()).Times(1)
+
+		u, _ := url.Parse(server.URL + "/manifest.tar.gz")
+		err = w.getHttpFile(u)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Check that apply was triggered
+		select {
+		case <-w.applyNotify:
+			// Good, apply was triggered
+		case <-time.After(100 * time.Millisecond):
+			Fail("Expected apply to be triggered")
+		}
+	})
+})
+
+var _ = Describe("cacheManifest with HTTP", func() {
+	var (
+		mockctl *gomock.Controller
+		mockLog *modelmocks.MockLogger
+		mockMgr *modelmocks.MockManager
+		w       *worker
+	)
+
+	BeforeEach(func() {
+		mockctl = gomock.NewController(GinkgoT())
+		mockLog = modelmocks.NewMockLogger(mockctl)
+		mockMgr = modelmocks.NewMockManager(mockctl)
+
+		mockLog.EXPECT().Debug(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Info(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Warn(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Error(gomock.Any(), gomock.Any()).AnyTimes()
+	})
+
+	AfterEach(func() {
+		mockctl.Finish()
+	})
+
+	It("routes http:// URLs to maintainHttpCache", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		w = &worker{
+			source: "http://example.com/manifest.tar.gz",
+			ctx:    ctx,
+			log:    mockLog,
+			mgr:    mockMgr,
+		}
+
+		var wg sync.WaitGroup
+		err := w.cacheManifest(&wg)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Give the goroutine time to start and create the channel
+		Eventually(func() chan struct{} {
+			return w.fetchNotify
+		}, 100*time.Millisecond).ShouldNot(BeNil())
+	})
+
+	It("routes https:// URLs to maintainHttpCache", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		w = &worker{
+			source: "https://example.com/manifest.tar.gz",
+			ctx:    ctx,
+			log:    mockLog,
+			mgr:    mockMgr,
+		}
+
+		var wg sync.WaitGroup
+		err := w.cacheManifest(&wg)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Give the goroutine time to start and create the channel
+		Eventually(func() chan struct{} {
+			return w.fetchNotify
+		}, 100*time.Millisecond).ShouldNot(BeNil())
+	})
+})

--- a/agent/object.go
+++ b/agent/object.go
@@ -1,0 +1,223 @@
+// Copyright (c) 2026, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/choria-io/ccm/internal/backoff"
+	iu "github.com/choria-io/ccm/internal/util"
+	"github.com/choria-io/ccm/metrics"
+)
+
+// maintainObjectCache periodically checks a JetStream Object Store for changes and updates the local cache.
+// It uses JetStream's native object watcher for real-time change detection.
+func (w *worker) maintainObjectCache(wg *sync.WaitGroup, bucket string, file string) {
+	ticker := time.NewTicker(objectMaintInterval)
+	updateNotify := make(chan struct{}, 1)
+	updateNotify <- struct{}{}
+	var watch jetstream.ObjectWatcher
+	var obj jetstream.ObjectStore
+
+	for {
+		select {
+		case <-updateNotify:
+			w.log.Debug("Checking for updates to JetStream bucket", "bucket", bucket, "file", file)
+			if w.js == nil {
+				if !w.setJetStream() {
+					continue
+				}
+			}
+
+			if obj == nil {
+				var ok bool
+				obj, ok = w.getBucket(bucket)
+				if !ok {
+					continue
+				}
+			}
+
+			if watch == nil {
+				watch, _ = w.watchFile(wg, obj, bucket, file)
+			}
+
+		case <-ticker.C:
+			ticker.Reset(objectMaintInterval)
+			updateNotify <- struct{}{}
+
+		case <-w.ctx.Done():
+			ticker.Stop()
+			if watch != nil {
+				watch.Stop()
+			}
+		}
+	}
+}
+
+// watchFile creates a watcher for changes to a specific file in the object store.
+func (w *worker) watchFile(wg *sync.WaitGroup, obj jetstream.ObjectStore, bucket string, file string) (jetstream.ObjectWatcher, bool) {
+	watch, err := obj.Watch(w.ctx, jetstream.UpdatesOnly())
+	if err != nil {
+		w.log.Error("Could not watch JetStream bucket", "error", err)
+		return nil, false
+	}
+
+	wg.Add(1)
+	go func(wg *sync.WaitGroup) {
+		defer wg.Done()
+
+		w.fetchNotify = make(chan struct{}, 1)
+		w.fetchNotify <- struct{}{}
+
+		tries := 0
+
+		for {
+			select {
+			case <-w.fetchNotify:
+				err := w.getFile(obj, bucket, file)
+				if err != nil {
+					metrics.AgentManifestFetchFailureCount.WithLabelValues(w.source).Inc()
+					tries++
+					w.log.Error("Could not fetch file from JetStream bucket", "error", err)
+					backoff.Default.AfterFunc(tries, func() {
+						select {
+						case w.fetchNotify <- struct{}{}:
+						default:
+						}
+					})
+					continue
+				}
+				tries = 0
+
+			case nfo := <-watch.Updates():
+				if nfo == nil {
+					continue
+				}
+
+				if nfo.Name != file {
+					continue
+				}
+
+				if nfo.Deleted {
+					w.log.Warn("File deleted from JetStream bucket, terminating management")
+					w.cancel(fmt.Errorf("file deleted from bucket"))
+					continue
+				}
+
+				select {
+				case w.fetchNotify <- struct{}{}:
+				default:
+				}
+
+			case <-w.ctx.Done():
+				watch.Stop() // should not be needed so no need to log errors
+				return
+			}
+		}
+	}(wg)
+
+	return watch, true
+}
+
+// getFile downloads a file from the object store and caches it locally.
+func (w *worker) getFile(obj jetstream.ObjectStore, bucket string, file string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	metrics.AgentManifestFetchCount.WithLabelValues(w.source).Inc()
+
+	w.log.Warn("Fetching file from JetStream bucket", "bucket", bucket, "file", file)
+	f, err := obj.Get(context.TODO(), file)
+	if err == nil {
+		err = f.Error()
+	}
+	if err != nil {
+		return fmt.Errorf("get failed: %w", err)
+	}
+
+	nfo, err := f.Info()
+	if err != nil {
+		return fmt.Errorf("info failed: %w", err)
+	}
+	w.log.Info("File updated in JetStream bucket, fetching", "size", nfo.Size)
+
+	tf, err := os.MkdirTemp(w.cacheDir, fmt.Sprintf("%s-%s.*", bucket, w.cleanFileName(file)))
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tf)
+
+	files, err := iu.UntarGz(f, tf)
+	if err != nil {
+		return err
+	}
+
+	manifestPath, err := iu.FindManifestInFiles(files, tf)
+	if err != nil {
+		return fmt.Errorf("%w in fetched file", err)
+	}
+
+	target := filepath.Join(w.cacheDir, fmt.Sprintf("%s_%s", bucket, w.cleanFileName(file)))
+	if iu.FileExists(target) {
+		err = os.RemoveAll(target)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = os.Rename(tf, target)
+	if err != nil {
+		return err
+	}
+
+	w.manifestPath = filepath.Join(target, manifestPath)
+
+	w.log.Debug("File moved to cache", "target", target, "manifest", w.manifestPath)
+	w.mgr.SetWorkingDirectory(filepath.Dir(w.manifestPath))
+
+	w.triggerApply()
+
+	return nil
+}
+
+// getBucket gets an object store bucket from JetStream.
+func (w *worker) getBucket(bucket string) (jetstream.ObjectStore, bool) {
+	obj, err := w.js.ObjectStore(w.ctx, bucket)
+	if err != nil {
+		w.log.Error("Could not connect to JetStream bucket", "bucket", bucket, "error", err)
+		return nil, false
+	}
+
+	return obj, true
+}
+
+// setJetStream initializes the JetStream connection.
+func (w *worker) setJetStream() bool {
+	var err error
+
+	w.js, err = w.mgr.JetStream()
+	if err != nil {
+		w.log.Error("Could not connect to JetStream", "error", err)
+		return false
+	}
+
+	return true
+}
+
+// cleanFileName removes tar.gz/tgz extensions from a filename.
+func (w *worker) cleanFileName(file string) string {
+	file = strings.TrimSuffix(file, ".tar.gz")
+	file = strings.TrimSuffix(file, ".tgz")
+
+	return file
+}

--- a/agent/object_test.go
+++ b/agent/object_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2026, R.I. Pienaar and the Choria Project contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"context"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	"github.com/choria-io/ccm/model/modelmocks"
+)
+
+// Tests are run via TestConfig in config_test.go
+
+var _ = Describe("cleanFileName", func() {
+	It("removes .tar.gz extension", func() {
+		w := &worker{}
+		result := w.cleanFileName("manifest.tar.gz")
+		Expect(result).To(Equal("manifest"))
+	})
+
+	It("removes .tgz extension", func() {
+		w := &worker{}
+		result := w.cleanFileName("manifest.tgz")
+		Expect(result).To(Equal("manifest"))
+	})
+
+	It("handles files without extension", func() {
+		w := &worker{}
+		result := w.cleanFileName("manifest")
+		Expect(result).To(Equal("manifest"))
+	})
+
+	It("handles files with other extensions", func() {
+		w := &worker{}
+		result := w.cleanFileName("manifest.yaml")
+		Expect(result).To(Equal("manifest.yaml"))
+	})
+
+	It("handles nested .tar.gz extensions", func() {
+		w := &worker{}
+		result := w.cleanFileName("manifest.tar.gz.tar.gz")
+		Expect(result).To(Equal("manifest.tar.gz"))
+	})
+})
+
+var _ = Describe("cacheManifest with obj://", func() {
+	var (
+		mockctl *gomock.Controller
+		mockLog *modelmocks.MockLogger
+		mockMgr *modelmocks.MockManager
+		w       *worker
+	)
+
+	BeforeEach(func() {
+		mockctl = gomock.NewController(GinkgoT())
+		mockLog = modelmocks.NewMockLogger(mockctl)
+		mockMgr = modelmocks.NewMockManager(mockctl)
+
+		mockLog.EXPECT().Debug(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Info(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Warn(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Error(gomock.Any(), gomock.Any()).AnyTimes()
+	})
+
+	AfterEach(func() {
+		mockctl.Finish()
+	})
+
+	It("routes obj:// URLs to maintainObjectCache", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Allow JetStream calls from the goroutine (will fail, causing retry loop)
+		mockMgr.EXPECT().JetStream().Return(nil, context.DeadlineExceeded).AnyTimes()
+
+		w = &worker{
+			source: "obj://mybucket/manifest.tar.gz",
+			ctx:    ctx,
+			log:    mockLog,
+			mgr:    mockMgr,
+		}
+
+		var wg sync.WaitGroup
+		err := w.cacheManifest(&wg)
+		Expect(err).NotTo(HaveOccurred())
+
+		// maintainObjectCache was launched as goroutine
+		// The JetStream call will fail, but routing worked
+	})
+
+	It("returns error for unsupported schemes", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		w = &worker{
+			source: "ftp://example.com/manifest.tar.gz",
+			ctx:    ctx,
+			log:    mockLog,
+			mgr:    mockMgr,
+		}
+
+		var wg sync.WaitGroup
+		err := w.cacheManifest(&wg)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unsupported manifest source"))
+	})
+})
+
+var _ = Describe("setJetStream", func() {
+	var (
+		mockctl *gomock.Controller
+		mockLog *modelmocks.MockLogger
+		mockMgr *modelmocks.MockManager
+		w       *worker
+	)
+
+	BeforeEach(func() {
+		mockctl = gomock.NewController(GinkgoT())
+		mockLog = modelmocks.NewMockLogger(mockctl)
+		mockMgr = modelmocks.NewMockManager(mockctl)
+
+		mockLog.EXPECT().Debug(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Info(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Warn(gomock.Any(), gomock.Any()).AnyTimes()
+		mockLog.EXPECT().Error(gomock.Any(), gomock.Any()).AnyTimes()
+	})
+
+	AfterEach(func() {
+		mockctl.Finish()
+	})
+
+	It("returns false when JetStream connection fails", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		w = &worker{
+			ctx: ctx,
+			log: mockLog,
+			mgr: mockMgr,
+		}
+
+		mockMgr.EXPECT().JetStream().Return(nil, context.DeadlineExceeded)
+
+		result := w.setJetStream()
+		Expect(result).To(BeFalse())
+		Expect(w.js).To(BeNil())
+	})
+})

--- a/agent/worker.go
+++ b/agent/worker.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -17,7 +16,6 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/choria-io/ccm/internal/backoff"
 	iu "github.com/choria-io/ccm/internal/util"
 	"github.com/choria-io/ccm/metrics"
 	"github.com/choria-io/ccm/model"
@@ -41,6 +39,11 @@ type worker struct {
 	externalData      map[string]any
 	lastApply         time.Time
 	agentApplyTrigger chan *worker
+
+	// HTTP cache state
+	httpLastModified   string
+	httpETag           string
+	httpNoCacheHeaders bool
 
 	mu sync.Mutex
 }
@@ -88,6 +91,11 @@ func (w *worker) cacheManifest(wg *sync.WaitGroup) error {
 		w.log.Info("Maintaining object cache for manifest", "bucket", uri.Host, "file", f)
 		go w.maintainObjectCache(wg, uri.Host, f)
 
+	case "http", "https":
+		redactedUrl := iu.RedactUrlCredentials(uri)
+		w.log.Info("Maintaining HTTP cache for manifest", "url", redactedUrl)
+		go w.maintainHttpCache(wg, uri)
+
 	case "":
 		w.manifestPath = w.source
 		w.mgr.SetWorkingDirectory(filepath.Dir(w.manifestPath))
@@ -98,200 +106,6 @@ func (w *worker) cacheManifest(wg *sync.WaitGroup) error {
 	}
 
 	return nil
-}
-
-func (w *worker) maintainObjectCache(wg *sync.WaitGroup, bucket string, file string) {
-	ticker := time.NewTicker(objectMaintInterval)
-	updateNotify := make(chan struct{}, 1)
-	updateNotify <- struct{}{}
-	var watch jetstream.ObjectWatcher
-	var obj jetstream.ObjectStore
-
-	for {
-		select {
-		case <-updateNotify:
-			w.log.Debug("Checking for updates to JetStream bucket", "bucket", bucket, "file", file)
-			if w.js == nil {
-				if !w.setJetStream() {
-					continue
-				}
-			}
-
-			if obj == nil {
-				var ok bool
-				obj, ok = w.getBucket(bucket)
-				if !ok {
-					continue
-				}
-			}
-
-			if watch == nil {
-				watch, _ = w.watchFile(wg, obj, bucket, file)
-			}
-
-		case <-ticker.C:
-			ticker.Reset(objectMaintInterval)
-			updateNotify <- struct{}{}
-
-		case <-w.ctx.Done():
-			ticker.Stop()
-			if watch != nil {
-				watch.Stop()
-			}
-		}
-	}
-}
-
-func (w *worker) watchFile(wg *sync.WaitGroup, obj jetstream.ObjectStore, bucket string, file string) (jetstream.ObjectWatcher, bool) {
-	watch, err := obj.Watch(w.ctx, jetstream.UpdatesOnly())
-	if err != nil {
-		w.log.Error("Could not watch JetStream bucket", "error", err)
-		return nil, false
-	}
-
-	wg.Add(1)
-	go func(wg *sync.WaitGroup) {
-		defer wg.Done()
-
-		w.fetchNotify = make(chan struct{}, 1)
-		w.fetchNotify <- struct{}{}
-
-		tries := 0
-
-		for {
-			select {
-			case <-w.fetchNotify:
-				err := w.getFile(obj, bucket, file)
-				if err != nil {
-					metrics.AgentManifestFetchFailureCount.WithLabelValues(w.source).Inc()
-					tries++
-					w.log.Error("Could not fetch file from JetStream bucket", "error", err)
-					backoff.Default.AfterFunc(tries, func() {
-						select {
-						case w.fetchNotify <- struct{}{}:
-						default:
-						}
-					})
-					continue
-				}
-				tries = 0
-
-			case nfo := <-watch.Updates():
-				if nfo == nil {
-					continue
-				}
-
-				if nfo.Name != file {
-					continue
-				}
-
-				if nfo.Deleted {
-					w.log.Warn("File deleted from JetStream bucket, terminating management")
-					w.cancel(fmt.Errorf("file deleted from bucket"))
-					continue
-				}
-
-				select {
-				case w.fetchNotify <- struct{}{}:
-				default:
-				}
-
-			case <-w.ctx.Done():
-				watch.Stop() // should not be needed so no need to log errors
-				return
-			}
-		}
-	}(wg)
-
-	return watch, true
-}
-
-func (w *worker) getFile(obj jetstream.ObjectStore, bucket string, file string) error {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	metrics.AgentManifestFetchCount.WithLabelValues(w.source).Inc()
-
-	w.log.Warn("Fetching file from JetStream bucket", "bucket", bucket, "file", file)
-	f, err := obj.Get(context.TODO(), file)
-	if err == nil {
-		err = f.Error()
-	}
-	if err != nil {
-		return fmt.Errorf("get failed: %w", err)
-	}
-
-	nfo, err := f.Info()
-	if err != nil {
-		return fmt.Errorf("info failed: %w", err)
-	}
-	w.log.Info("File updated in JetStream bucket, fetching", "size", nfo.Size)
-
-	tf, err := os.MkdirTemp(w.cacheDir, fmt.Sprintf("%s-%s.*", bucket, w.cleanFileName(file)))
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(tf)
-
-	files, err := iu.UntarGz(f, tf)
-	if err != nil {
-		return err
-	}
-
-	var manifestPath string
-	for _, f := range files {
-		if filepath.Base(f) == "manifest.yaml" {
-			manifestPath = strings.TrimPrefix(f, tf)
-			break
-		}
-	}
-	if manifestPath == "" {
-		return fmt.Errorf("manifest.yaml not found in fetched file")
-	}
-
-	target := filepath.Join(w.cacheDir, fmt.Sprintf("%s_%s", bucket, w.cleanFileName(file)))
-	if iu.FileExists(target) {
-		err = os.RemoveAll(target)
-		if err != nil {
-			return err
-		}
-	}
-
-	err = os.Rename(tf, target)
-	if err != nil {
-		return err
-	}
-
-	w.manifestPath = filepath.Join(target, manifestPath)
-
-	w.log.Debug("File moved to cache", "target", target, "manifest", w.manifestPath)
-	w.mgr.SetWorkingDirectory(filepath.Dir(w.manifestPath))
-
-	w.triggerApply()
-
-	return nil
-}
-
-func (w *worker) getBucket(bucket string) (jetstream.ObjectStore, bool) {
-	obj, err := w.js.ObjectStore(w.ctx, bucket)
-	if err != nil {
-		w.log.Error("Could not connect to JetStream bucket", "bucket", bucket, "error", err)
-		return nil, false
-	}
-
-	return obj, true
-}
-
-func (w *worker) setJetStream() bool {
-	var err error
-
-	w.js, err = w.mgr.JetStream()
-	if err != nil {
-		w.log.Error("Could not connect to JetStream", "error", err)
-		return false
-	}
-
-	return true
 }
 
 func (w *worker) triggerApply() {
@@ -362,13 +176,6 @@ func (w *worker) apply(hcOnly bool, force bool) *model.SessionSummary {
 	}
 
 	return report
-}
-
-func (w *worker) cleanFileName(file string) string {
-	file = strings.TrimSuffix(file, ".tar.gz")
-	file = strings.TrimSuffix(file, ".tgz")
-
-	return file
 }
 
 func (w *worker) setFacts(facts map[string]any) {

--- a/docs/content/agent/_index.md
+++ b/docs/content/agent/_index.md
@@ -22,6 +22,12 @@ By enabling both modes at the same time you can run monitoring very frequently -
 
 While enabling the combination is optional, it is recommended, and so we also recommend using health checks in your key resources.
 
+## Supported Manifest snd Data Sources
+
+For Hiera data we support Key-Value stores as a local file, Key-Value values and HTTP(s) URLs.
+
+For the manifest bundles you can point to a local file, a Object Storage URL or a HTTP(s) URL.
+
 ## Logical Flow
 
 The agent continuously run and manage manifests in the following way:

--- a/docs/content/hiera/_index.md
+++ b/docs/content/hiera/_index.md
@@ -175,6 +175,14 @@ We can now parse the hierarchy using system facts, this is identical to using th
 $ ccm hiera parse kv://CCM/data --context ccm -S
 ```
 
+### Data on Web Servers
+
+As above NATS example, you can also just store your Key-Value data on a web server and use the `http` protocol to fetch it.
+
+```
+$ ccm hiera parse https://example.net/site.yaml -S
+```
+
 ### Go example
 
 Supply a YAML document and a map of facts. The resolver will parse the hierarchy, replace `{{ lookup('facts.fact') }}` placeholders, and merge the matching sections.

--- a/docs/content/resources/_index.md
+++ b/docs/content/resources/_index.md
@@ -17,6 +17,17 @@ All resources can have an `alias` set which will be used in logging and to find 
 
 All resources can have a `require` property that is a list of `type#name` or `type#alias` that must have succeeded before this resource can be applied.
 
+## About Names
+
+Resources can be specified like:
+
+```yaml
+/etc/motd:
+  ensure: present
+```
+
+This sets `name` to `/etc/motd`, in the following paragraphs we will refer to this as `name`.
+
 ## Exec
 
 When you manage an exec resource, you describe a command that should be executed to bring the system into the desired state. The exec resource is idempotent when used with the `creates` property or `refreshonly` mode.
@@ -27,8 +38,7 @@ When you manage an exec resource, you describe a command that should be executed
 In a manifest:
 
 ```yaml
-exec:
-  name: /usr/bin/touch /tmp/hello
+/usr/bin/touch /tmp/hello:
   ensure: present
   creates: /tmp/hello
   timeout: 30s
@@ -54,6 +64,7 @@ The `ensure` property does not have meaning for the exec resource.
 | Property                |                                                                                               |
 |-------------------------|-----------------------------------------------------------------------------------------------|
 | `name`                  | The command to execute                                                                        |
+| `command`               | When set will use this is the command to run instead of `name`                                |
 | `ensure`                | The desired state                                                                             |
 | `cwd`                   | The working directory from which to run the command                                           |
 | `environment` (array)   | Additional environment variables in KEY=VALUE format                                          |
@@ -82,8 +93,7 @@ The `file` type is very minimal at the moment, most important TODO items:
 In a manifest:
 
 ```yaml
-file:
-  name: /etc/motd
+/etc/motd:
   ensure: present
   content: |
     Managed by CCM {{ now() }}
@@ -173,8 +183,7 @@ Additionally, a service can listen to the state changes of another resource, and
 In a manifest:
 
 ```yaml
-service:
-  name: httpd
+httpd:
   ensure: running
   enable: true
   subscribe: package#httpd

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/itchyny/gojq v0.12.18 // indirect
 	github.com/itchyny/timefmt-go v0.1.7 // indirect
-	github.com/klauspost/compress v1.18.2 // indirect
+	github.com/klauspost/compress v1.18.3 // indirect
 	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
-github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
-github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
+github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=
+github.com/klauspost/compress v1.18.3/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/hiera/resolver_test.go
+++ b/hiera/resolver_test.go
@@ -7,6 +7,9 @@ package hiera
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
@@ -695,8 +698,8 @@ var _ = Describe("ResolveUrl", func() {
 	})
 
 	It("returns an error for unsupported schemes", func() {
-		_, err := ResolveUrl(ctx, "http://example.com/data", mockMgr, nil, DefaultOptions, mockLog)
-		Expect(err).To(MatchError("unsupported hiera data source: http://example.com/data"))
+		_, err := ResolveUrl(ctx, "ftp://example.com/data", mockMgr, nil, DefaultOptions, mockLog)
+		Expect(err).To(MatchError("unsupported hiera data source: ftp://example.com/data"))
 	})
 
 	It("resolves kv:// URLs", func() {
@@ -818,6 +821,229 @@ overrides:
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(map[string]any{
 			"log_level": "WARN",
+		}))
+	})
+})
+
+var _ = Describe("ResolveHttp", func() {
+	var (
+		ctrl    *gomock.Controller
+		mockLog *modelmocks.MockLogger
+		ctx     context.Context
+		server  *httptest.Server
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockLog = modelmocks.NewMockLogger(ctrl)
+		ctx = context.Background()
+
+		mockLog.EXPECT().Debug(gomock.Any(), gomock.Any()).AnyTimes()
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+		if server != nil {
+			server.Close()
+		}
+	})
+
+	It("returns an error when URL is empty", func() {
+		_, err := ResolveHttp(ctx, "", nil, DefaultOptions, mockLog)
+		Expect(err).To(MatchError("URL is required for HTTP hiera data source"))
+	})
+
+	It("returns an error when URL is invalid", func() {
+		_, err := ResolveHttp(ctx, "://invalid", nil, DefaultOptions, mockLog)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid URL"))
+	})
+
+	It("returns an error when connection fails", func() {
+		_, err := ResolveHttp(ctx, "http://localhost:59999/nonexistent", nil, DefaultOptions, mockLog)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to fetch hiera data"))
+	})
+
+	It("resolves JSON data from HTTP URL", func() {
+		jsonData := `{
+			"hierarchy": {
+				"order": ["default"],
+				"merge": "first"
+			},
+			"data": {
+				"log_level": "INFO",
+				"port": 8080
+			}
+		}`
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(jsonData))
+		}))
+
+		result, err := ResolveHttp(ctx, server.URL+"/config.json", map[string]any{}, DefaultOptions, mockLog)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(map[string]any{
+			"log_level": "INFO",
+			"port":      8080,
+		}))
+	})
+
+	It("resolves YAML data from HTTP URL", func() {
+		yamlData := `
+hierarchy:
+  order:
+    - default
+  merge: first
+data:
+  log_level: DEBUG
+  timeout: 30
+`
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/yaml")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(yamlData))
+		}))
+
+		result, err := ResolveHttp(ctx, server.URL+"/config.yaml", map[string]any{}, DefaultOptions, mockLog)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(map[string]any{
+			"log_level": "DEBUG",
+			"timeout":   30,
+		}))
+	})
+
+	It("resolves data with facts and hierarchy overrides", func() {
+		jsonData := `{
+			"hierarchy": {
+				"order": ["env:prod", "default"],
+				"merge": "deep"
+			},
+			"data": {
+				"log_level": "INFO",
+				"retries": 3
+			},
+			"overrides": {
+				"env:prod": {
+					"log_level": "WARN",
+					"retries": 5
+				}
+			}
+		}`
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(jsonData))
+		}))
+
+		facts := map[string]any{"env": "prod"}
+		result, err := ResolveHttp(ctx, server.URL+"/config.json", facts, DefaultOptions, mockLog)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(map[string]any{
+			"log_level": "WARN",
+			"retries":   5,
+		}))
+	})
+
+	It("handles HTTP Basic Auth from URL credentials", func() {
+		var receivedAuth string
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedAuth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data": {"key": "value"}}`))
+		}))
+
+		parsedURL, err := url.Parse(server.URL)
+		Expect(err).ToNot(HaveOccurred())
+		parsedURL.User = url.UserPassword("testuser", "testpass")
+
+		_, err = ResolveHttp(ctx, parsedURL.String()+"/config.json", map[string]any{}, DefaultOptions, mockLog)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(receivedAuth).To(HavePrefix("Basic "))
+	})
+
+	It("returns error for non-200 status codes", func() {
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+
+		_, err := ResolveHttp(ctx, server.URL+"/notfound", map[string]any{}, DefaultOptions, mockLog)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("status 404"))
+	})
+
+	It("returns error for empty response body", func() {
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		_, err := ResolveHttp(ctx, server.URL+"/empty", map[string]any{}, DefaultOptions, mockLog)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("empty"))
+	})
+
+	It("returns error for invalid JSON", func() {
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{invalid json`))
+		}))
+
+		_, err := ResolveHttp(ctx, server.URL+"/invalid", map[string]any{}, DefaultOptions, mockLog)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to parse"))
+	})
+
+	It("returns error for invalid YAML", func() {
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("invalid:\n  yaml:\n bad indentation"))
+		}))
+
+		_, err := ResolveHttp(ctx, server.URL+"/invalid", map[string]any{}, DefaultOptions, mockLog)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to parse"))
+	})
+})
+
+var _ = Describe("ResolveUrl with HTTP", func() {
+	var (
+		ctrl    *gomock.Controller
+		mockMgr *modelmocks.MockManager
+		mockLog *modelmocks.MockLogger
+		ctx     context.Context
+		server  *httptest.Server
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockMgr = modelmocks.NewMockManager(ctrl)
+		mockLog = modelmocks.NewMockLogger(ctrl)
+		ctx = context.Background()
+
+		mockLog.EXPECT().Debug(gomock.Any(), gomock.Any()).AnyTimes()
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+		if server != nil {
+			server.Close()
+		}
+	})
+
+	It("resolves http:// URLs", func() {
+		jsonData := `{
+			"hierarchy": {"order": ["default"], "merge": "first"},
+			"data": {"setting": "http_value"}
+		}`
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(jsonData))
+		}))
+
+		result, err := ResolveUrl(ctx, server.URL+"/config.json", mockMgr, map[string]any{}, DefaultOptions, mockLog)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(map[string]any{
+			"setting": "http_value",
 		}))
 	})
 })

--- a/internal/fs/schemas/manifest.json
+++ b/internal/fs/schemas/manifest.json
@@ -315,7 +315,11 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "The command to execute"
+          "description": "A descriptive name for the resource, or the command to execute if 'command' is not specified"
+        },
+        "command": {
+          "type": "string",
+          "description": "The command to execute. If not specified, the 'name' property will be used as the command."
         },
         "alias": {
           "type": "string",
@@ -547,6 +551,10 @@
       "type": "object",
       "description": "Properties for an exec resource that runs commands",
       "properties": {
+        "command": {
+          "type": "string",
+          "description": "The command to execute. If not specified, the resource name (key) will be used as the command."
+        },
         "alias": {
           "type": "string",
           "description": "An alternative name for the resource that can be used in require/subscribe references"

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -7,15 +7,19 @@ package util
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"golang.org/x/term"
 )
@@ -314,4 +318,91 @@ func IsValidResourceRef(refs ...string) bool {
 // IsTerminal determines if stdout is a terminal
 func IsTerminal() bool {
 	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// FindManifestInFiles searches a list of file paths for manifest.yaml and returns its path.
+// If stripPrefix is provided, it will be removed from the returned path.
+// Returns an error if manifest.yaml is not found.
+func FindManifestInFiles(files []string, stripPrefix string) (string, error) {
+	for _, f := range files {
+		if filepath.Base(f) == "manifest.yaml" {
+			if stripPrefix != "" {
+				return strings.TrimPrefix(f, stripPrefix), nil
+			}
+			return f, nil
+		}
+	}
+	return "", fmt.Errorf("manifest.yaml not found")
+}
+
+// RedactUrlCredentials returns a URL string with credentials replaced by [REDACTED]
+func RedactUrlCredentials(u *url.URL) string {
+	if u.User == nil {
+		return u.String()
+	}
+
+	// Copy the URL and overwrite credentials
+	redacted := *u
+	redacted.User = url.User("[REDACTED]")
+	return redacted.String()
+}
+
+// HttpGetResult contains the result of an HTTP GET request
+type HttpGetResult struct {
+	Body       []byte
+	StatusCode int
+	Status     string
+}
+
+// HttpGet performs an HTTP GET request with optional timeout and basic auth from URL credentials.
+// If timeout is 0 or negative, defaults to 1 minute.
+func HttpGet(ctx context.Context, rawUrl string, timeout time.Duration) (*HttpGetResult, error) {
+	if rawUrl == "" {
+		return nil, fmt.Errorf("URL is required")
+	}
+
+	parsedUrl, err := url.Parse(rawUrl)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+
+	if parsedUrl.Scheme != "http" && parsedUrl.Scheme != "https" {
+		return nil, fmt.Errorf("URL scheme must be http or https, got %q", parsedUrl.Scheme)
+	}
+
+	if timeout <= 0 {
+		timeout = time.Minute
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(timeoutCtx, http.MethodGet, rawUrl, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	// Add Basic Auth if credentials are provided in the URL
+	if parsedUrl.User != nil {
+		username := parsedUrl.User.Username()
+		password, _ := parsedUrl.User.Password()
+		req.SetBasicAuth(username, password)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return &HttpGetResult{
+		Body:       body,
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+	}, nil
 }

--- a/model/resource_exec.go
+++ b/model/resource_exec.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2025-2026, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -27,6 +27,7 @@ const (
 // ExecResourceProperties defines the properties for an exec resource
 type ExecResourceProperties struct {
 	CommonResourceProperties `yaml:",inline"`
+	Command                  string   `json:"command" yaml:"command"`                             // Command specifies the command to run, when not set will use the name property
 	Cwd                      string   `json:"cwd,omitempty" yaml:"cwd,omitempty"`                 // Cwd specifies the working directory from which to run the command
 	Environment              []string `json:"environment,omitempty" yaml:"environment,omitempty"` // Environment specifies additional environment variables to set when running the command
 	Path                     string   `json:"path,omitempty" yaml:"path,omitempty"`               // Path specifies the search path for executable commands, as an array of directories or a colon-separated list

--- a/resources/apply/apply_test.go
+++ b/resources/apply/apply_test.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"testing"
 
@@ -720,41 +719,6 @@ var _ = Describe("ResolveManifestHttpUrl", func() {
 		_, _, _, err := ResolveManifestHttpUrl(ctx, mockMgr, "http://user:pass@localhost:59999/manifest.tar.gz", mockLog)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to fetch manifest from URL"))
-	})
-})
-
-var _ = Describe("redactUrlCredentials", func() {
-	It("returns URL unchanged when no credentials present", func() {
-		u, _ := url.Parse("https://example.com/path/to/file.tar.gz")
-		result := redactUrlCredentials(u)
-		Expect(result).To(Equal("https://example.com/path/to/file.tar.gz"))
-	})
-
-	It("redacts username and password from URL", func() {
-		u, _ := url.Parse("https://myuser:secretpass@example.com/path/to/file.tar.gz")
-		result := redactUrlCredentials(u)
-		Expect(result).To(Equal("https://%5BREDACTED%5D@example.com/path/to/file.tar.gz"))
-		Expect(result).NotTo(ContainSubstring("myuser"))
-		Expect(result).NotTo(ContainSubstring("secretpass"))
-	})
-
-	It("redacts username-only credentials from URL", func() {
-		u, _ := url.Parse("https://myuser@example.com/path/to/file.tar.gz")
-		result := redactUrlCredentials(u)
-		Expect(result).To(Equal("https://%5BREDACTED%5D@example.com/path/to/file.tar.gz"))
-		Expect(result).NotTo(ContainSubstring("myuser"))
-	})
-
-	It("preserves query parameters and fragments", func() {
-		u, _ := url.Parse("https://user:pass@example.com/path?query=value#fragment")
-		result := redactUrlCredentials(u)
-		Expect(result).To(Equal("https://%5BREDACTED%5D@example.com/path?query=value#fragment"))
-	})
-
-	It("preserves port numbers", func() {
-		u, _ := url.Parse("https://user:pass@example.com:8443/path/to/file.tar.gz")
-		result := redactUrlCredentials(u)
-		Expect(result).To(Equal("https://%5BREDACTED%5D@example.com:8443/path/to/file.tar.gz"))
 	})
 })
 

--- a/resources/exec/posix/posix.go
+++ b/resources/exec/posix/posix.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2025-2026, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -28,7 +28,12 @@ func NewPosixProvider(log model.Logger, runner model.CommandRunner) (*Provider, 
 }
 
 func (p *Provider) Execute(ctx context.Context, properties *model.ExecResourceProperties, log model.Logger) (int, error) {
-	words, err := shellquote.Split(properties.Name)
+	cmd := properties.Name
+	if properties.Command != "" {
+		cmd = properties.Command
+	}
+
+	words, err := shellquote.Split(cmd)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
This allows agent to fetch manifest tarballs over http. If the webserver supports the standard ways to detect file age and file modification the agent will periodically check for updated bundles and deploy them locally

Additionally we add 'command' to exec which will override 'name' as a means of setting command which will work better for the new manifest styles

We also add a JSON schema that describe the manifests and the apply package will validate resolved manifest match the schema before apply - so even jet generated resources are validated

The schema can be used in editors to provide assisted editing of manifests and will be published in our usual schema repo