### PR TITLE
(#73) Add a control structure for resources

### DIFF
--- a/cmd/ensure_exec.go
+++ b/cmd/ensure_exec.go
@@ -39,6 +39,7 @@ func (c *ensureExecCommand) execAction(_ *fisk.ParseContext) error {
 			Name:     c.command,
 			Ensure:   model.EnsurePresent,
 			Provider: c.parent.provider,
+			Control:  c.parent.control(),
 		},
 		Returns:     c.returns,
 		Timeout:     c.timeout,

--- a/docs/content/resources/_index.md
+++ b/docs/content/resources/_index.md
@@ -17,6 +17,35 @@ All resources can have an `alias` set which will be used in logging and to find 
 
 All resources can have a `require` property that is a list of `type#name` or `type#alias` that must have succeeded before this resource can be applied.
 
+## Conditional Resource Execution
+
+Resources can be conditionally executed using a `control` section and expressions that should resolve to boolean values.
+
+```
+package:
+  name: zsh
+  ensure: 5.9
+  control:
+    if: lookup("facts.host.info.os") == "linux"
+    unless: lookup("facts.host.info.virtualizationSystem") == "docker"
+```
+
+Here we install `zsh` on all `linux` machines unless they are running inside a `docker` container.
+
+Here's a table that shows how the 2 booleans inercept:
+
+| `if`      | `unless`  | Resource Managed? |
+|-----------|-----------|-------------------|
+| (not set) | (not set) | Yes               |
+| `true`    | (not set) | Yes               |
+| `false`   | (not set) | No                |
+| (not set) | `true`    | No                |
+| (not set) | `false`   | Yes               |
+| `true`    | `true`    | No                |
+| `true`    | `false`   | Yes               |
+| `false`   | `true`    | No                |
+| `false`   | `false`   | No                |
+
 ## About Names
 
 Resources can be specified like:

--- a/internal/fs/schemas/manifest.json
+++ b/internal/fs/schemas/manifest.json
@@ -188,6 +188,9 @@
             "type": "string",
             "pattern": "^[a-z]+#.+$"
           }
+        },
+        "control": {
+          "$ref": "#/$defs/resourceControl"
         }
       },
       "required": ["name"],
@@ -229,6 +232,9 @@
             "type": "string",
             "pattern": "^[a-z]+#.+$"
           }
+        },
+        "control": {
+          "$ref": "#/$defs/resourceControl"
         },
         "enable": {
           "type": "boolean",
@@ -282,6 +288,9 @@
             "type": "string",
             "pattern": "^[a-z]+#.+$"
           }
+        },
+        "control": {
+          "$ref": "#/$defs/resourceControl"
         },
         "content": {
           "type": "string",
@@ -349,6 +358,9 @@
             "type": "string",
             "pattern": "^[a-z]+#.+$"
           }
+        },
+        "control": {
+          "$ref": "#/$defs/resourceControl"
         },
         "cwd": {
           "type": "string",
@@ -437,6 +449,9 @@
             "type": "string",
             "pattern": "^[a-z]+#.+$"
           }
+        },
+        "control": {
+          "$ref": "#/$defs/resourceControl"
         }
       },
       "additionalProperties": false
@@ -473,6 +488,9 @@
             "type": "string",
             "pattern": "^[a-z]+#.+$"
           }
+        },
+        "control": {
+          "$ref": "#/$defs/resourceControl"
         },
         "enable": {
           "type": "boolean",
@@ -521,6 +539,9 @@
             "type": "string",
             "pattern": "^[a-z]+#.+$"
           }
+        },
+        "control": {
+          "$ref": "#/$defs/resourceControl"
         },
         "content": {
           "type": "string",
@@ -583,6 +604,9 @@
             "type": "string",
             "pattern": "^[a-z]+#.+$"
           }
+        },
+        "control": {
+          "$ref": "#/$defs/resourceControl"
         },
         "cwd": {
           "type": "string",
@@ -674,6 +698,23 @@
         }
       },
       "required": ["command"],
+      "additionalProperties": false
+    },
+    "resourceControl": {
+      "type": "object",
+      "description": "Control conditions that determine whether a resource should be managed",
+      "properties": {
+        "if": {
+          "type": "string",
+          "description": "Expression that must evaluate to true for the resource to be managed. Has access to Facts, Data, and Environ variables.",
+          "examples": ["Facts.os == \"linux\"", "lookup(\"facts.kernel\", \"\") == \"Linux\""]
+        },
+        "unless": {
+          "type": "string",
+          "description": "Expression that must evaluate to false for the resource to be managed. Has access to Facts, Data, and Environ variables.",
+          "examples": ["Facts.os == \"windows\"", "lookup(\"facts.virtual\", \"\") == \"docker\""]
+        }
+      },
       "additionalProperties": false
     }
   }

--- a/model/resource.go
+++ b/model/resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, R.I. Pienaar and the Choria Project contributors
+// Copyright (c) 2025-2026, R.I. Pienaar and the Choria Project contributors
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -47,14 +47,20 @@ type ResourceProperties interface {
 
 // CommonResourceProperties contains properties shared by all resource types
 type CommonResourceProperties struct {
-	Type         string              `json:"-" yaml:"-"`
-	Name         string              `json:"name" yaml:"name"`
-	Alias        string              `json:"alias,omitempty" yaml:"alias,omitempty"`
-	Ensure       string              `json:"ensure,omitempty" yaml:"ensure,omitempty"`
-	Provider     string              `json:"provider,omitempty" yaml:"provider,omitempty"`
-	HealthChecks []CommonHealthCheck `json:"health_checks,omitempty" yaml:"health_checks,omitempty"`
-	Require      []string            `json:"require,omitempty" yaml:"require,omitempty"`
-	SkipValidate bool                `json:"-" yaml:"-"`
+	Type         string                 `json:"-" yaml:"-"`
+	Name         string                 `json:"name" yaml:"name"`
+	Alias        string                 `json:"alias,omitempty" yaml:"alias,omitempty"`
+	Ensure       string                 `json:"ensure,omitempty" yaml:"ensure,omitempty"`
+	Provider     string                 `json:"provider,omitempty" yaml:"provider,omitempty"`
+	HealthChecks []CommonHealthCheck    `json:"health_checks,omitempty" yaml:"health_checks,omitempty"`
+	Require      []string               `json:"require,omitempty" yaml:"require,omitempty"`
+	Control      *CommonResourceControl `json:"control,omitempty" yaml:"control,omitempty"`
+	SkipValidate bool                   `json:"-" yaml:"-"`
+}
+
+type CommonResourceControl struct {
+	ManageIf     string `json:"if,omitempty" yaml:"if,omitempty"`
+	ManageUnless string `json:"unless,omitempty" yaml:"unless,omitempty"`
 }
 
 // ResolveTemplates resolves template expressions in common resource properties


### PR DESCRIPTION
Resources can have ManageIf and ManageUnless properties set that can influence if a resource should be managed or not in the manifest

Accessible on the CLI and in Manifests