### PR TITLE
Fix: Misleading error "invalid resource: file path must be absolute"

### DIFF
--- a/model/resource_archive.go
+++ b/model/resource_archive.go
@@ -128,7 +128,7 @@ func (p *ArchiveResourceProperties) Validate() error {
 	}
 
 	if filepath.Clean(p.Name) != p.Name {
-		return fmt.Errorf("file path must be absolute")
+		return fmt.Errorf("file path must be canonical")
 	}
 
 	if !filepath.IsAbs(p.Name) {

--- a/model/resource_archive_test.go
+++ b/model/resource_archive_test.go
@@ -47,8 +47,8 @@ var _ = Describe("ArchiveResourceProperties", func() {
 
 			// Name validation
 			Entry("empty name", "", "present", "https://example.com/archive.tar.gz", "root", "root", "", "", "name"),
-			Entry("path with ..", "/tmp/../etc/archive.tar.gz", "present", "https://example.com/archive.tar.gz", "root", "root", "", "", "absolute"),
-			Entry("path with .", "/tmp/./archive.tar.gz", "present", "https://example.com/archive.tar.gz", "root", "root", "", "", "absolute"),
+			Entry("path with ..", "/tmp/../etc/archive.tar.gz", "present", "https://example.com/archive.tar.gz", "root", "root", "", "", "canonical"),
+			Entry("path with .", "/tmp/./archive.tar.gz", "present", "https://example.com/archive.tar.gz", "root", "root", "", "", "canonical"),
 
 			// URL validation
 			Entry("empty url", "/tmp/archive.tar.gz", "present", "", "root", "root", "", "", "url cannot be empty"),


### PR DESCRIPTION
Draft fix for https://github.com/choria-io/ccm/issues/144

Draft prepared via targeted patch mode.
Validation command not configured in automation.

Changed files:
- `model/resource_archive.go`
- `model/resource_archive_test.go`
