### PR TITLE
(#239) Fix file/archive ownership across bind-mounted volumes

### DIFF
--- a/docs/content/design/new/_index.md
+++ b/docs/content/design/new/_index.md
@@ -671,6 +671,29 @@ if err != nil {
 }
 ```
 
+### File Ownership and Mode
+
+When a provider creates a file by writing to a temp file and renaming it into place, apply ownership and mode **by path after the rename**, not by file descriptor before it:
+
+```go
+err = os.Rename(tf.Name(), file)
+if err != nil {
+    return err
+}
+
+// chown before chmod: chown(2) clears setuid/setgid bits.
+err = os.Chown(file, uid, gid)
+if err != nil {
+    return err
+}
+
+return os.Chmod(file, parsedMode)
+```
+
+`fchown(2)` via `*os.File.Chown` is silently dropped by some shared-filesystem backends — notably Docker Desktop bind mounts on macOS/Windows (VirtioFS, gRPC-FUSE) and various FUSE-backed shares. The fchown call returns success but the ownership change does not survive the rename, leaving the target file owned by the caller. Path-based `chown(2)` and `chmod(2)` are forwarded correctly by these layers, so applying them after the rename is portable.
+
+See `resources/file/posix/posix.go` (`Store`, `SetAttributes`) and `resources/archive/http/http.go` (`Download`) for the established pattern.
+
 ### Template Resolution
 
 Template resolution uses a reflection-based struct walker (`templates.ResolveStructTemplates`) that automatically resolves `{{ expression }}` placeholders in all string-typed fields. The walker recurses into all composite types including slices, maps, nested structs, and pointer fields.

--- a/resources/archive/http/http.go
+++ b/resources/archive/http/http.go
@@ -63,6 +63,12 @@ func (p *Provider) Download(ctx context.Context, properties *model.ArchiveResour
 	parent := filepath.Dir(properties.Name)
 	archiveName := filepath.Base(uri.Path)
 
+	// validate checks owner/group are always set
+	uid, gid, err := iu.LookupOwnerGroup(properties.Owner, properties.Group)
+	if err != nil {
+		return err
+	}
+
 	tf, err := os.CreateTemp(parent, fmt.Sprintf("%s-*", archiveName))
 	if err != nil {
 		return err
@@ -70,13 +76,6 @@ func (p *Provider) Download(ctx context.Context, properties *model.ArchiveResour
 	defer os.Remove(tf.Name())
 
 	p.log.Info("Saving archive", "dest", properties.Name, "tf", tf.Name())
-
-	// validate checks this is always set
-	err = iu.ChownFile(tf, properties.Owner, properties.Group)
-	if err != nil {
-		tf.Close()
-		return err
-	}
 
 	copied, err := io.Copy(tf, resp.Body)
 	if err != nil {
@@ -100,7 +99,14 @@ func (p *Provider) Download(ctx context.Context, properties *model.ArchiveResour
 		}
 	}
 
-	return os.Rename(tf.Name(), properties.Name)
+	err = os.Rename(tf.Name(), properties.Name)
+	if err != nil {
+		return err
+	}
+
+	// chown by path rather than fd: some filesystems (Docker Desktop bind
+	// mounts via VirtioFS/gRPC-FUSE) silently drop fchown across a rename.
+	return os.Chown(properties.Name, uid, gid)
 }
 
 func (p *Provider) Extract(ctx context.Context, properties *model.ArchiveResourceProperties, log model.Logger) error {

--- a/resources/archive/type.go
+++ b/resources/archive/type.go
@@ -175,9 +175,10 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 			return nil, err
 		}
 
-		isStable, _, _ = t.isDesiredState(properties, finalStatus)
+		var reason string
+		isStable, reason, _ = t.isDesiredState(properties, finalStatus)
 		if !isStable {
-			return nil, fmt.Errorf("%w: %s", model.ErrDesiredStateFailed, properties.Ensure)
+			return nil, fmt.Errorf("%w: %s: %s", model.ErrDesiredStateFailed, properties.Ensure, reason)
 		}
 	}
 
@@ -186,9 +187,15 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 	return finalStatus, nil
 }
 
+// isDesiredState reports whether state matches properties. The second return is
+// a human-readable reason describing the mismatch when stable is false, suitable
+// for inclusion in error messages.
 func (t *Type) isDesiredState(properties *model.ArchiveResourceProperties, state *model.ArchiveState) (bool, string, error) {
 	if properties.Ensure == model.EnsureAbsent {
-		return state.Ensure == model.EnsureAbsent, "", nil
+		if state.Ensure == model.EnsureAbsent {
+			return true, "", nil
+		}
+		return false, fmt.Sprintf("archive still exists (ensure=%s)", state.Ensure), nil
 	}
 
 	meta := state.Metadata
@@ -196,36 +203,36 @@ func (t *Type) isDesiredState(properties *model.ArchiveResourceProperties, state
 	// If Creates is specified, the extraction marker file must exist
 	if properties.Creates != "" && !meta.CreatesExists {
 		t.log.Debug("Creates file does not exist", "creates", properties.Creates)
-		return false, "", nil
+		return false, fmt.Sprintf("creates path missing: %s", properties.Creates), nil
 	}
 
 	// If cleanup is true and creates is not set the archive file must not exist
 	if properties.Cleanup && properties.Creates == "" && meta.ArchiveExists {
 		t.log.Debug("Archive file exists and cleanup is true")
-		return false, "", nil
+		return false, "archive file still present despite cleanup=true", nil
 	}
 
 	// If Cleanup is false, the archive file must exist
 	if !properties.Cleanup && !meta.ArchiveExists {
 		t.log.Debug("Archive file does not exist and cleanup is false")
-		return false, "", nil
+		return false, "archive file missing", nil
 	}
 
 	// If archive exists, verify owner, group, and checksum
 	if meta.ArchiveExists {
 		if !iu.UserIDMatches(properties.Owner, meta.Owner) {
 			t.log.Debug("Owner does not match", "state", meta.Owner, "requested", properties.Owner)
-			return false, "", nil
+			return false, fmt.Sprintf("owner mismatch: state=%s requested=%s", meta.Owner, properties.Owner), nil
 		}
 
 		if !iu.GroupIDMatches(properties.Group, meta.Group) {
 			t.log.Debug("Group does not match", "state", meta.Group, "requested", properties.Group)
-			return false, "", nil
+			return false, fmt.Sprintf("group mismatch: state=%s requested=%s", meta.Group, properties.Group), nil
 		}
 
 		if properties.Checksum != "" && meta.Checksum != properties.Checksum {
 			t.log.Debug("Checksum does not match", "state", meta.Checksum, "requested", properties.Checksum)
-			return false, "", nil
+			return false, fmt.Sprintf("checksum mismatch: state=%s requested=%s", meta.Checksum, properties.Checksum), nil
 		}
 	}
 

--- a/resources/exec/type.go
+++ b/resources/exec/type.go
@@ -118,7 +118,7 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 		return nil, err
 	}
 
-	isStable := t.isDesiredState(properties, initialStatus)
+	isStable, _ := t.isDesiredState(properties, initialStatus)
 	switch {
 	case shouldRefreshViaSubscribe:
 		t.log.Info("Refreshing via subscribe", "subscribe", refreshResource)
@@ -167,8 +167,9 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 	}
 
 	if !noop {
-		if !t.isDesiredState(properties, finalStatus) {
-			return nil, fmt.Errorf("%w: exit code %d", model.ErrDesiredStateFailed, exitCode)
+		stable, reason := t.isDesiredState(properties, finalStatus)
+		if !stable {
+			return nil, fmt.Errorf("%w: exit code %d: %s", model.ErrDesiredStateFailed, exitCode, reason)
 		}
 	}
 
@@ -181,23 +182,26 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 	return finalStatus, nil
 }
 
-func (t *Type) isDesiredState(properties *model.ExecResourceProperties, status *model.ExecState) bool {
+// isDesiredState reports whether status matches properties. The second return is
+// a human-readable reason describing the mismatch when stable is false, suitable
+// for inclusion in error messages.
+func (t *Type) isDesiredState(properties *model.ExecResourceProperties, status *model.ExecState) (bool, string) {
 	if properties.Creates != "" && status.CreatesSatisfied {
-		return true
+		return true, ""
 	}
 
 	if status.ExitCode == nil {
 		if properties.OnlyIf != "" && !status.OnlyIfSatisfied {
-			return true
+			return true, ""
 		}
 
 		if properties.Unless != "" && status.UnlessSatisfied {
-			return true
+			return true, ""
 		}
 	}
 
 	if status.ExitCode == nil && properties.RefreshOnly {
-		return true
+		return true, ""
 	}
 
 	returns := []int{0}
@@ -206,10 +210,13 @@ func (t *Type) isDesiredState(properties *model.ExecResourceProperties, status *
 	}
 
 	if status.ExitCode != nil {
-		return slices.Contains(returns, *status.ExitCode)
+		if slices.Contains(returns, *status.ExitCode) {
+			return true, ""
+		}
+		return false, fmt.Sprintf("exit code %d not in allowed returns %v", *status.ExitCode, returns)
 	}
 
-	return false
+	return false, "command did not run and no guard short-circuited"
 }
 
 func (t *Type) selectProviderUnlocked() error {

--- a/resources/exec/type_test.go
+++ b/resources/exec/type_test.go
@@ -141,6 +141,8 @@ var _ = Describe("Exec Type", func() {
 	Describe("isDesiredState", func() {
 		var exec *Type
 
+		stable := func(b bool, _ string) bool { return b }
+
 		BeforeEach(func(ctx context.Context) {
 			properties := &model.ExecResourceProperties{
 				CommonResourceProperties: model.CommonResourceProperties{
@@ -157,13 +159,13 @@ var _ = Describe("Exec Type", func() {
 			It("Should return true when Creates is satisfied", func() {
 				exec.prop.Creates = "/tmp/marker"
 				status := &model.ExecState{CreatesSatisfied: true}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeTrue())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeTrue())
 			})
 
 			It("Should return false when Creates is not satisfied", func() {
 				exec.prop.Creates = "/tmp/marker"
 				status := &model.ExecState{CreatesSatisfied: false}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeFalse())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeFalse())
 			})
 		})
 
@@ -171,37 +173,37 @@ var _ = Describe("Exec Type", func() {
 			It("Should return true when RefreshOnly and no exit code", func() {
 				exec.prop.RefreshOnly = true
 				status := &model.ExecState{ExitCode: nil}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeTrue())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeTrue())
 			})
 
 			It("Should check exit code when RefreshOnly but has exit code", func() {
 				exec.prop.RefreshOnly = true
 				status := &model.ExecState{ExitCode: intPtr(0)}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeTrue())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeTrue())
 
 				status = &model.ExecState{ExitCode: intPtr(1)}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeFalse())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeFalse())
 			})
 		})
 
 		Context("with exit code checks", func() {
 			It("Should return true when exit code is 0 with default returns", func() {
 				status := &model.ExecState{ExitCode: intPtr(0)}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeTrue())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeTrue())
 			})
 
 			It("Should return false when exit code is non-zero with default returns", func() {
 				status := &model.ExecState{ExitCode: intPtr(1)}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeFalse())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeFalse())
 			})
 
 			It("Should use custom returns when specified", func() {
 				exec.prop.Returns = []int{0, 1, 2}
 				status := &model.ExecState{ExitCode: intPtr(1)}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeTrue())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeTrue())
 
 				status = &model.ExecState{ExitCode: intPtr(3)}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeFalse())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeFalse())
 			})
 		})
 
@@ -209,19 +211,19 @@ var _ = Describe("Exec Type", func() {
 			It("Should return true when OnlyIf set and not satisfied", func() {
 				exec.prop.OnlyIf = "test -f /tmp/ready"
 				status := &model.ExecState{OnlyIfSatisfied: false}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeTrue())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeTrue())
 			})
 
 			It("Should return false when OnlyIf set and satisfied", func() {
 				exec.prop.OnlyIf = "test -f /tmp/ready"
 				status := &model.ExecState{OnlyIfSatisfied: true}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeFalse())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeFalse())
 			})
 
 			It("Should not check OnlyIf when ExitCode is set", func() {
 				exec.prop.OnlyIf = "test -f /tmp/ready"
 				status := &model.ExecState{OnlyIfSatisfied: false, ExitCode: intPtr(0)}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeTrue())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeTrue())
 			})
 		})
 
@@ -229,19 +231,19 @@ var _ = Describe("Exec Type", func() {
 			It("Should return true when Unless set and satisfied", func() {
 				exec.prop.Unless = "pgrep myapp"
 				status := &model.ExecState{UnlessSatisfied: true}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeTrue())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeTrue())
 			})
 
 			It("Should return false when Unless set and not satisfied", func() {
 				exec.prop.Unless = "pgrep myapp"
 				status := &model.ExecState{UnlessSatisfied: false}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeFalse())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeFalse())
 			})
 
 			It("Should not check Unless when ExitCode is set", func() {
 				exec.prop.Unless = "pgrep myapp"
 				status := &model.ExecState{UnlessSatisfied: true, ExitCode: intPtr(0)}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeTrue())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeTrue())
 			})
 		})
 
@@ -250,7 +252,7 @@ var _ = Describe("Exec Type", func() {
 				exec.prop.Creates = "/tmp/marker"
 				exec.prop.OnlyIf = "test -f /tmp/ready"
 				status := &model.ExecState{CreatesSatisfied: true, OnlyIfSatisfied: true}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeTrue())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeTrue())
 			})
 		})
 
@@ -258,7 +260,7 @@ var _ = Describe("Exec Type", func() {
 			It("Should return false when no exit code and not RefreshOnly", func() {
 				exec.prop.RefreshOnly = false
 				status := &model.ExecState{ExitCode: nil}
-				Expect(exec.isDesiredState(exec.prop, status)).To(BeFalse())
+				Expect(stable(exec.isDesiredState(exec.prop, status))).To(BeFalse())
 			})
 		})
 	})

--- a/resources/file/posix/posix.go
+++ b/resources/file/posix/posix.go
@@ -83,6 +83,11 @@ func (p *Provider) Store(ctx context.Context, file string, contents []byte, sour
 		return err
 	}
 
+	uid, gid, err := iu.LookupOwnerGroup(owner, group)
+	if err != nil {
+		return err
+	}
+
 	var sf *os.File
 
 	if source != "" {
@@ -99,21 +104,12 @@ func (p *Provider) Store(ctx context.Context, file string, contents []byte, sour
 	}
 	defer tf.Close()
 	defer os.Remove(tf.Name())
-	err = tf.Chmod(parsedMode)
-	if err != nil {
-		return err
-	}
 
 	if sf != nil {
 		_, err = io.Copy(tf, sf)
 	} else {
 		_, err = tf.Write(contents)
 	}
-	if err != nil {
-		return err
-	}
-
-	err = iu.ChownFile(tf, owner, group)
 	if err != nil {
 		return err
 	}
@@ -128,7 +124,16 @@ func (p *Provider) Store(ctx context.Context, file string, contents []byte, sour
 		return fmt.Errorf("could not rename temporary file: %w", err)
 	}
 
-	return nil
+	// chown and chmod by path rather than fd: some filesystems (Docker
+	// Desktop bind mounts via VirtioFS/gRPC-FUSE) silently drop fchown
+	// across a rename. chown runs before chmod because chown(2) clears
+	// setuid/setgid bits.
+	err = os.Chown(file, uid, gid)
+	if err != nil {
+		return err
+	}
+
+	return os.Chmod(file, parsedMode)
 }
 
 // SetAttributes updates owner, group and mode on an existing regular file

--- a/resources/file/type.go
+++ b/resources/file/type.go
@@ -177,9 +177,10 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 	}
 
 	if !noop {
-		isStable, _, _ = t.isDesiredState(properties, finalStatus)
+		var reason string
+		isStable, reason, _ = t.isDesiredState(properties, finalStatus)
 		if !isStable {
-			return nil, fmt.Errorf("%w: %s", model.ErrDesiredStateFailed, properties.Ensure)
+			return nil, fmt.Errorf("%w: %s: %s", model.ErrDesiredStateFailed, properties.Ensure, reason)
 		}
 	}
 
@@ -188,22 +189,30 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 	return finalStatus, nil
 }
 
+// isDesiredState reports whether state matches properties. The second return is
+// a human-readable reason describing the mismatch when stable is false, suitable
+// for inclusion in error messages.
 func (t *Type) isDesiredState(properties *model.FileResourceProperties, state *model.FileState) (bool, string, error) {
 	if properties.Ensure == model.EnsureAbsent {
 		t.log.Debug("Checking if file is absent due to ensure=absent", "ensure", state.Ensure)
-		return state.Ensure == model.EnsureAbsent, "", nil
+		if state.Ensure == model.EnsureAbsent {
+			return true, "", nil
+		}
+		return false, fmt.Sprintf("file still exists (ensure=%s)", state.Ensure), nil
 	}
 
-	var contentChecksum string
-	var err error
 	meta := state.Metadata
 
 	if properties.Ensure != state.Ensure {
 		t.log.Debug("Ensure does not match", "requested", properties.Ensure, "state", state.Ensure)
-		return false, "", nil
+		return false, fmt.Sprintf("ensure mismatch: state=%s requested=%s", state.Ensure, properties.Ensure), nil
 	}
 
 	if properties.Ensure != model.FileEnsureDirectory && properties.ManagesContent() {
+		var (
+			contentChecksum string
+			err             error
+		)
 		if properties.Source != "" {
 			path := t.adjustedSource(properties)
 			contentChecksum, err = iu.Sha256HashFile(path)
@@ -219,18 +228,18 @@ func (t *Type) isDesiredState(properties *model.FileResourceProperties, state *m
 
 		if contentChecksum != meta.Checksum {
 			t.log.Debug("Content does not match", "requested", contentChecksum, "state", meta.Checksum)
-			return false, contentChecksum, nil
+			return false, fmt.Sprintf("content checksum mismatch: state=%s requested=%s", meta.Checksum, contentChecksum), nil
 		}
 	}
 
 	if !iu.UserIDMatches(properties.Owner, meta.Owner) {
 		t.log.Debug("Owner does not match", "state", meta.Owner, "requested", properties.Owner)
-		return false, contentChecksum, nil
+		return false, fmt.Sprintf("owner mismatch: state=%s requested=%s", meta.Owner, properties.Owner), nil
 	}
 
 	if !iu.GroupIDMatches(properties.Group, meta.Group) {
 		t.log.Debug("Group does not match", "state", meta.Group, "requested", properties.Group)
-		return false, contentChecksum, nil
+		return false, fmt.Sprintf("group mismatch: state=%s requested=%s", meta.Group, properties.Group), nil
 	}
 
 	desiredMode := properties.Mode
@@ -243,10 +252,10 @@ func (t *Type) isDesiredState(properties *model.FileResourceProperties, state *m
 
 	if meta.Mode != desiredMode {
 		t.log.Debug("Mode does not match", "state", meta.Mode, "requested", desiredMode)
-		return false, contentChecksum, nil
+		return false, fmt.Sprintf("mode mismatch: state=%s requested=%s", meta.Mode, desiredMode), nil
 	}
 
-	return true, contentChecksum, nil
+	return true, "", nil
 }
 
 func (t *Type) Info(ctx context.Context) (any, error) {

--- a/resources/package/type.go
+++ b/resources/package/type.go
@@ -100,6 +100,8 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 		return nil, err
 	}
 
+	initialStable, _ := t.isDesiredState(properties, initialStatus)
+
 	switch {
 	case properties.Ensure == "":
 		return nil, model.ErrInvalidEnsureValue
@@ -131,7 +133,7 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 
 		refreshState = true
 
-	case t.isDesiredState(properties, initialStatus):
+	case initialStable:
 		// nothing to do
 
 	case properties.Ensure == EnsureAbsent:
@@ -220,8 +222,9 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 	}
 
 	if !noop {
-		if !t.isDesiredState(properties, finalStatus) {
-			return nil, fmt.Errorf("%w: %s", model.ErrDesiredStateFailed, properties.Ensure)
+		stable, reason := t.isDesiredState(properties, finalStatus)
+		if !stable {
+			return nil, fmt.Errorf("%w: %s: %s", model.ErrDesiredStateFailed, properties.Ensure, reason)
 		}
 	}
 
@@ -234,24 +237,35 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 	return finalStatus, nil
 }
 
-func (t *Type) isDesiredState(properties *model.PackageResourceProperties, state *model.PackageState) bool {
+// isDesiredState reports whether state matches properties. The second return is
+// a human-readable reason describing the mismatch when stable is false, suitable
+// for inclusion in error messages.
+func (t *Type) isDesiredState(properties *model.PackageResourceProperties, state *model.PackageState) (bool, string) {
 	switch properties.Ensure {
 	case EnsurePresent: // anything but absent is ok
-		return state.Ensure != EnsureAbsent
+		if state.Ensure != EnsureAbsent {
+			return true, ""
+		}
+		return false, "package is absent, expected present"
 
 	case EnsureAbsent: // only absent is ok
-		return state.Ensure == EnsureAbsent
+		if state.Ensure == EnsureAbsent {
+			return true, ""
+		}
+		return false, fmt.Sprintf("package version %s installed, expected absent", state.Ensure)
 
 	case EnsureLatest: // we dont really know if its latest, OS can lie about it, latest is a bad idea so we check absent
-		return state.Ensure != EnsureAbsent
+		if state.Ensure != EnsureAbsent {
+			return true, ""
+		}
+		return false, "package is absent, expected latest"
 
 	default:
 		if iu.VersionCmp(state.Ensure, properties.Ensure, false) == 0 {
-			return true
+			return true, ""
 		}
+		return false, fmt.Sprintf("version mismatch: state=%s requested=%s", state.Ensure, properties.Ensure)
 	}
-
-	return false
 }
 
 // Info returns the current status of the package

--- a/resources/package/type_test.go
+++ b/resources/package/type_test.go
@@ -48,6 +48,8 @@ var _ = Describe("Package Type", func() {
 	Describe("isDesiredState", func() {
 		var pkg *Type
 
+		stable := func(b bool, _ string) bool { return b }
+
 		BeforeEach(func(ctx context.Context) {
 			properties := &model.PackageResourceProperties{
 				CommonResourceProperties: model.CommonResourceProperties{
@@ -68,7 +70,7 @@ var _ = Describe("Package Type", func() {
 				state := &model.PackageState{
 					CommonResourceState: model.CommonResourceState{Ensure: stateEnsure},
 				}
-				Expect(pkg.isDesiredState(props, state)).To(Equal(expected))
+				Expect(stable(pkg.isDesiredState(props, state))).To(Equal(expected))
 			},
 			Entry("present matches any version", EnsurePresent, "1.2.3", true),
 			Entry("present does not match absent", EnsurePresent, EnsureAbsent, false),
@@ -385,7 +387,7 @@ var _ = Describe("Package Type", func() {
 
 				event, err := pkg.Apply(ctx)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(event.Errors).To(ContainElement("failed to reach desired state: absent"))
+				Expect(event.Errors).To(ContainElement(ContainSubstring("failed to reach desired state: absent")))
 			})
 
 			Context("with health check", func() {

--- a/resources/scaffold/type.go
+++ b/resources/scaffold/type.go
@@ -108,7 +108,7 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 		return nil, err
 	}
 
-	isStable, err := t.isDesiredState(properties, initialStatus, true)
+	isStable, _, err := t.isDesiredState(properties, initialStatus, true)
 	if err != nil {
 		return nil, err
 	}
@@ -149,12 +149,12 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 		return nil, err
 	}
 
-	isStable, err = t.isDesiredState(properties, finalStatus, false)
+	isStable, reason, err := t.isDesiredState(properties, finalStatus, false)
 	if err != nil {
 		return nil, err
 	}
 	if !isStable {
-		return nil, fmt.Errorf("%w: %s", model.ErrDesiredStateFailed, properties.Ensure)
+		return nil, fmt.Errorf("%w: %s: %s", model.ErrDesiredStateFailed, properties.Ensure, reason)
 	}
 
 	t.FinalizeState(finalStatus, false, "", true, true, false)
@@ -182,7 +182,10 @@ func (t *Type) noopAffected(properties *model.ScaffoldResourceProperties, state 
 	return affected, verb
 }
 
-func (t *Type) isDesiredState(properties *model.ScaffoldResourceProperties, state *model.ScaffoldState, fromStatus bool) (bool, error) {
+// isDesiredState reports whether state matches properties. The second return is
+// a human-readable reason describing the mismatch when stable is false, suitable
+// for inclusion in error messages.
+func (t *Type) isDesiredState(properties *model.ScaffoldResourceProperties, state *model.ScaffoldState, fromStatus bool) (bool, string, error) {
 	meta := state.Metadata
 	changedCount := len(meta.Changed)
 	stableCount := len(meta.Stable)
@@ -193,19 +196,28 @@ func (t *Type) isDesiredState(properties *model.ScaffoldResourceProperties, stat
 
 	if properties.Ensure == model.EnsureAbsent {
 		if !meta.TargetExists {
-			return true, nil
+			return true, "", nil
 		}
 		t.log.Debug("desired state", "changed", meta.Changed, "stable", stableCount, "purged", purgedCount, "exist", meta.TargetExists)
-		return stableCount == 0 && changedCount == 0, nil
+		if stableCount == 0 && changedCount == 0 {
+			return true, "", nil
+		}
+		return false, fmt.Sprintf("target still has %d stable and %d changed files", stableCount, changedCount), nil
 	}
 
 	// a status call should show changes were made
 	if fromStatus {
-		return changedCount == 0 && stableCount > 0 && purgedCount == 0, nil
+		if changedCount == 0 && stableCount > 0 && purgedCount == 0 {
+			return true, "", nil
+		}
+		return false, fmt.Sprintf("scaffold needs work: changed=%d stable=%d purged=%d", changedCount, stableCount, purgedCount), nil
 	}
 
 	// a non status call should show that some changes were made or we have stable files
-	return changedCount > 0 || stableCount > 0 || purgedCount > 0, nil
+	if changedCount > 0 || stableCount > 0 || purgedCount > 0 {
+		return true, "", nil
+	}
+	return false, "scaffold produced no changed, stable, or purged files", nil
 }
 
 func (t *Type) Info(ctx context.Context) (any, error) {

--- a/resources/scaffold/type_test.go
+++ b/resources/scaffold/type_test.go
@@ -866,7 +866,7 @@ var _ = Describe("Scaffold Type", func() {
 					},
 				}
 
-				stable, err := scaffold.isDesiredState(props, state, true)
+				stable, _, err := scaffold.isDesiredState(props, state, true)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stable).To(BeTrue())
 			})
@@ -885,7 +885,7 @@ var _ = Describe("Scaffold Type", func() {
 					},
 				}
 
-				stable, err := scaffold.isDesiredState(props, state, true)
+				stable, _, err := scaffold.isDesiredState(props, state, true)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stable).To(BeFalse())
 			})
@@ -904,7 +904,7 @@ var _ = Describe("Scaffold Type", func() {
 					},
 				}
 
-				stable, err := scaffold.isDesiredState(props, state, true)
+				stable, _, err := scaffold.isDesiredState(props, state, true)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stable).To(BeFalse())
 			})
@@ -923,7 +923,7 @@ var _ = Describe("Scaffold Type", func() {
 					},
 				}
 
-				stable, err := scaffold.isDesiredState(props, state, true)
+				stable, _, err := scaffold.isDesiredState(props, state, true)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stable).To(BeTrue())
 			})
@@ -942,7 +942,7 @@ var _ = Describe("Scaffold Type", func() {
 					},
 				}
 
-				stable, err := scaffold.isDesiredState(props, state, true)
+				stable, _, err := scaffold.isDesiredState(props, state, true)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stable).To(BeFalse())
 			})
@@ -963,7 +963,7 @@ var _ = Describe("Scaffold Type", func() {
 					},
 				}
 
-				desired, err := scaffold.isDesiredState(props, state, false)
+				desired, _, err := scaffold.isDesiredState(props, state, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(desired).To(BeTrue())
 			})
@@ -982,7 +982,7 @@ var _ = Describe("Scaffold Type", func() {
 					},
 				}
 
-				desired, err := scaffold.isDesiredState(props, state, false)
+				desired, _, err := scaffold.isDesiredState(props, state, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(desired).To(BeTrue())
 			})
@@ -1001,7 +1001,7 @@ var _ = Describe("Scaffold Type", func() {
 					},
 				}
 
-				desired, err := scaffold.isDesiredState(props, state, false)
+				desired, _, err := scaffold.isDesiredState(props, state, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(desired).To(BeTrue())
 			})
@@ -1020,7 +1020,7 @@ var _ = Describe("Scaffold Type", func() {
 					},
 				}
 
-				desired, err := scaffold.isDesiredState(props, state, false)
+				desired, _, err := scaffold.isDesiredState(props, state, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(desired).To(BeFalse())
 			})
@@ -1042,7 +1042,7 @@ var _ = Describe("Scaffold Type", func() {
 					},
 				}
 
-				stable, err := scaffold.isDesiredState(props, state, true)
+				stable, _, err := scaffold.isDesiredState(props, state, true)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stable).To(BeTrue())
 			})
@@ -1062,7 +1062,7 @@ var _ = Describe("Scaffold Type", func() {
 					},
 				}
 
-				stable, err := scaffold.isDesiredState(props, state, true)
+				stable, _, err := scaffold.isDesiredState(props, state, true)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stable).To(BeTrue())
 			})
@@ -1082,7 +1082,7 @@ var _ = Describe("Scaffold Type", func() {
 					},
 				}
 
-				stable, err := scaffold.isDesiredState(props, state, true)
+				stable, _, err := scaffold.isDesiredState(props, state, true)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stable).To(BeFalse())
 			})
@@ -1102,7 +1102,7 @@ var _ = Describe("Scaffold Type", func() {
 					},
 				}
 
-				stable, err := scaffold.isDesiredState(props, state, true)
+				stable, _, err := scaffold.isDesiredState(props, state, true)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stable).To(BeFalse())
 			})
@@ -1122,7 +1122,7 @@ var _ = Describe("Scaffold Type", func() {
 					},
 				}
 
-				stable, err := scaffold.isDesiredState(props, state, true)
+				stable, _, err := scaffold.isDesiredState(props, state, true)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stable).To(BeTrue())
 			})

--- a/resources/service/type.go
+++ b/resources/service/type.go
@@ -212,8 +212,9 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 	}
 
 	if !noop {
-		if !t.isDesiredState(properties, finalStatus) {
-			return nil, fmt.Errorf("%w: %s", model.ErrDesiredStateFailed, properties.Ensure)
+		stable, reason := t.isDesiredState(properties, finalStatus)
+		if !stable {
+			return nil, fmt.Errorf("%w: %s: %s", model.ErrDesiredStateFailed, properties.Ensure, reason)
 		}
 	}
 
@@ -226,25 +227,28 @@ func (t *Type) ApplyResource(ctx context.Context) (model.ResourceState, error) {
 	return finalStatus, nil
 }
 
-func (t *Type) isDesiredState(properties *model.ServiceResourceProperties, state *model.ServiceState) bool {
+// isDesiredState reports whether state matches properties. The second return is
+// a human-readable reason describing the mismatch when stable is false, suitable
+// for inclusion in error messages.
+func (t *Type) isDesiredState(properties *model.ServiceResourceProperties, state *model.ServiceState) (bool, string) {
 	switch {
 	case properties.Ensure == model.ServiceEnsureStopped && state.Ensure != model.ServiceEnsureStopped:
-		return false
+		return false, fmt.Sprintf("service is %s, expected stopped", state.Ensure)
 
 	case properties.Ensure == model.ServiceEnsureRunning && state.Ensure != model.ServiceEnsureRunning:
-		return false
+		return false, fmt.Sprintf("service is %s, expected running", state.Ensure)
 	}
 
 	switch {
 	case properties.Enable == nil:
 		// just leave it alone
 	case *properties.Enable && !state.Metadata.Enabled:
-		return false
+		return false, "service is disabled, expected enabled"
 	case !*properties.Enable && state.Metadata.Enabled:
-		return false
+		return false, "service is enabled, expected disabled"
 	}
 
-	return true
+	return true, ""
 }
 
 func (t *Type) Info(ctx context.Context) (any, error) {

--- a/resources/service/type_test.go
+++ b/resources/service/type_test.go
@@ -53,6 +53,8 @@ var _ = Describe("Service Type", func() {
 	Describe("isDesiredState", func() {
 		var svc *Type
 
+		stable := func(b bool, _ string) bool { return b }
+
 		BeforeEach(func(ctx context.Context) {
 			properties := &model.ServiceResourceProperties{
 				CommonResourceProperties: model.CommonResourceProperties{
@@ -73,7 +75,7 @@ var _ = Describe("Service Type", func() {
 				state := &model.ServiceState{
 					CommonResourceState: model.CommonResourceState{Ensure: stateEnsure},
 				}
-				Expect(svc.isDesiredState(props, state)).To(Equal(expected))
+				Expect(stable(svc.isDesiredState(props, state))).To(Equal(expected))
 			},
 			Entry("running matches running", model.ServiceEnsureRunning, model.ServiceEnsureRunning, true),
 			Entry("running does not match stopped", model.ServiceEnsureRunning, model.ServiceEnsureStopped, false),
@@ -91,7 +93,7 @@ var _ = Describe("Service Type", func() {
 					CommonResourceState: model.CommonResourceState{Ensure: model.ServiceEnsureRunning},
 					Metadata:            &model.ServiceMetadata{Enabled: stateEnabled},
 				}
-				Expect(svc.isDesiredState(props, state)).To(Equal(expected))
+				Expect(stable(svc.isDesiredState(props, state))).To(Equal(expected))
 			},
 			Entry("enable true matches enabled", boolPtr(true), true, true),
 			Entry("enable true does not match disabled", boolPtr(true), false, false),
@@ -552,7 +554,7 @@ var _ = Describe("Service Type", func() {
 
 				event, err := svc.Apply(ctx)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(event.Errors).To(ContainElement("failed to reach desired state: running"))
+				Expect(event.Errors).To(ContainElement(ContainSubstring("failed to reach desired state: running")))
 			})
 
 			Context("with health check", func() {


### PR DESCRIPTION
The posix file provider and HTTP archive provider used fchown on a temp file before renaming it into place. On Docker Desktop bind mounts (VirtioFS/gRPC-FUSE) and other FUSE-backed shares, fchown is silently dropped across the rename, leaving the file owned by the caller instead of the requested owner. Switch both providers to chown by path after the rename, matching the existing SetAttributes pattern.

Also propagate the specific mismatch (owner/group/mode/checksum/...) in "failed to reach desired state" errors across all resource types, so the ERROR log alone is enough to diagnose these failures instead of having to re-run with --debug.